### PR TITLE
Add topic & node dependency graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# rtui
-
+# rtui2
 [![PyPI - Version](https://img.shields.io/pypi/v/rtui2)](https://pypi.org/project/rtui2/)
 
 TUI tool for ROS 2 Topic/Node debugging
+
+![output](https://github.com/user-attachments/assets/576b9ecd-81cd-4b26-948c-65cea6ce49af)
 
 ## Support
 

--- a/rtui2/ros/dependency_graph.py
+++ b/rtui2/ros/dependency_graph.py
@@ -20,9 +20,7 @@ class RosDependencyGraph:
         self._max_depth = max_depth
         self.root = self._build_graph(root_entity, depth=0)
 
-    def _build_graph(
-        self, entity: RosEntity, depth: int
-    ) -> RosDependencyNode:
+    def _build_graph(self, entity: RosEntity, depth: int) -> RosDependencyNode:
         if depth > self._max_depth:
             return RosDependencyNode(entity)
 
@@ -48,7 +46,7 @@ class RosDependencyGraph:
             for pub_info in info.publishers:
                 pub_node_name = pub_info[0]
                 node_entity = RosEntity.new_node(pub_node_name)
-                child_node = self._build_graph(node_entity, depth + 1)
+                child_node = self._build_graph(node_entity, depth)
                 children.append(child_node)
 
         return RosDependencyNode(entity, children)

--- a/rtui2/ros/dependency_graph.py
+++ b/rtui2/ros/dependency_graph.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .entity import RosEntity, RosEntityType
+from .client import RosClient
+
+
+@dataclass
+class RosDependencyNode:
+    entity: RosEntity
+    children: list[RosDependencyNode] = field(default_factory=list)
+
+
+class RosDependencyGraph:
+    def __init__(self, root_entity: RosEntity, ros_client: RosClient) -> None:
+        self._ros = ros_client
+        self.root = self._build_graph(root_entity, visited=set())
+
+    def _build_graph(
+        self,
+        entity: RosEntity,
+        visited: set[str]
+    ) -> RosDependencyNode:
+        key = f"{entity.type}:{entity.name}"
+        if key in visited:
+            return RosDependencyNode(entity)
+
+        visited.add(key)
+        children: list[RosDependencyNode] = []
+
+        try:
+            info = self._ros.get_entity_info(entity)
+        except Exception:
+            return RosDependencyNode(entity)
+
+        if entity.type == RosEntityType.Node:
+            # Node → Subscribed Topics
+            for topic_name, _ in info.subscribers:
+                if topic_name == "/parameter_events":
+                    continue
+
+                topic_entity = RosEntity.new_topic(topic_name)
+                child_node = self._build_graph(topic_entity, visited)
+                children.append(child_node)
+
+        elif entity.type == RosEntityType.Topic:
+            # Topic → Publisher Nodes
+            for pub_info in info.publishers:
+                pub_node_name = pub_info[0]
+                node_entity = RosEntity.new_node(pub_node_name)
+                child_node = self._build_graph(node_entity, visited)
+                children.append(child_node)
+
+        return RosDependencyNode(entity, children)

--- a/rtui2/ros/dependency_graph.py
+++ b/rtui2/ros/dependency_graph.py
@@ -18,10 +18,10 @@ class RosDependencyGraph:
     ) -> None:
         self._ros = ros_client
         self._max_depth = max_depth
-        self.root = self._build_graph(root_entity, depth=0, visited=set())
+        self.root = self._build_graph(root_entity, depth=0)
 
     def _build_graph(
-        self, entity: RosEntity, depth: int, visited: set[str]
+        self, entity: RosEntity, depth: int
     ) -> RosDependencyNode:
         if depth > self._max_depth:
             return RosDependencyNode(entity)
@@ -40,7 +40,7 @@ class RosDependencyGraph:
                     continue
 
                 topic_entity = RosEntity.new_topic(topic_name)
-                child_node = self._build_graph(topic_entity, depth + 1, visited)
+                child_node = self._build_graph(topic_entity, depth + 1)
                 children.append(child_node)
 
         elif entity.type == RosEntityType.Topic:
@@ -48,7 +48,7 @@ class RosDependencyGraph:
             for pub_info in info.publishers:
                 pub_node_name = pub_info[0]
                 node_entity = RosEntity.new_node(pub_node_name)
-                child_node = self._build_graph(node_entity, depth + 1, visited)
+                child_node = self._build_graph(node_entity, depth + 1)
                 children.append(child_node)
 
         return RosDependencyNode(entity, children)

--- a/rtui2/ros/dependency_graph.py
+++ b/rtui2/ros/dependency_graph.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
-from dataclasses import dataclass, field
-from typing import Optional
 
-from .entity import RosEntity, RosEntityType
+from dataclasses import dataclass, field
+
 from .client import RosClient
+from .entity import RosEntity, RosEntityType
 
 
 @dataclass
@@ -14,20 +14,14 @@ class RosDependencyNode:
 
 class RosDependencyGraph:
     def __init__(
-        self,
-        root_entity: RosEntity,
-        ros_client: RosClient,
-        max_depth: int = 1
+        self, root_entity: RosEntity, ros_client: RosClient, max_depth: int = 1
     ) -> None:
         self._ros = ros_client
         self._max_depth = max_depth
         self.root = self._build_graph(root_entity, depth=0, visited=set())
 
     def _build_graph(
-        self,
-        entity: RosEntity,
-        depth: int,
-        visited: set[str]
+        self, entity: RosEntity, depth: int, visited: set[str]
     ) -> RosDependencyNode:
         if depth > self._max_depth:
             return RosDependencyNode(entity)

--- a/rtui2/ros/entity.py
+++ b/rtui2/ros/entity.py
@@ -152,9 +152,9 @@ class NodeInfo(RosEntityInfo):
     def to_textual(self) -> str:
         text = f"""[b]Node:[/b] {self.name}
 
-[b]Publishers:[/b]{_common_entities_with_type(self.publishers, "topic_link", "msg_type_link")}
+[b]Publishes:[/b]{_common_entities_with_type(self.publishers, "topic_link", "msg_type_link")}
 
-[b]Subscribers:[/b]{_common_entities_with_type(self.subscribers, "topic_link", "msg_type_link")}
+[b]Subscribes:[/b]{_common_entities_with_type(self.subscribers, "topic_link", "msg_type_link")}
 
 [b]Service Servers:[/b]{_common_entities_with_type(self.service_servers, "service_link", "srv_type_link")}
 """

--- a/rtui2/screens.py
+++ b/rtui2/screens.py
@@ -82,6 +82,6 @@ class RosEntityInspection(Screen):
                         yield self._info_panel
                 else:
                     with ScrollableContainer(id="main-upper", classes="main-half"):
-                        yield self._info_panel
-                    with ScrollableContainer(classes="main-half"):
                         yield self._definition_panel
+                    with ScrollableContainer(classes="main-half"):
+                        yield self._info_panel

--- a/rtui2/screens.py
+++ b/rtui2/screens.py
@@ -57,8 +57,7 @@ class RosEntityInspection(Screen):
             update_interval=5.0,
         )
         self._graph_panel = RosEntityGraphPanel(
-            ros,
-            None,
+            ros, None, on_highlighted_changed=self._info_panel.set_entity
         )
         if entity_type.has_definition():
             self._definition_panel = RosTypeDefinitionPanel(ros)

--- a/rtui2/screens.py
+++ b/rtui2/screens.py
@@ -6,7 +6,7 @@ from textual.screen import Screen
 from textual.widgets import Footer
 
 from .ros import RosClient, RosEntity, RosEntityType
-from .widgets import RosEntityInfoPanel, RosEntityListPanel, RosTypeDefinitionPanel
+from .widgets import RosEntityInfoPanel, RosEntityListPanel, RosEntityGraphPanel, RosTypeDefinitionPanel
 
 
 class RosEntityInspection(Screen):
@@ -14,6 +14,7 @@ class RosEntityInspection(Screen):
     _entity_name: str | None
     _list_panel: RosEntityListPanel
     _info_panel: RosEntityInfoPanel
+    _graph_panel: RosEntityGraphPanel
     _definition_panel: RosTypeDefinitionPanel | None = None
 
     DEFAULT_CSS = """
@@ -50,6 +51,10 @@ class RosEntityInspection(Screen):
             None,
             update_interval=5.0,
         )
+        self._graph_panel = RosEntityGraphPanel(
+            ros,
+            None,
+        )
         if entity_type.has_definition():
             self._definition_panel = RosTypeDefinitionPanel(ros)
 
@@ -57,6 +62,7 @@ class RosEntityInspection(Screen):
         self._entity_name = name
         entity = RosEntity(type=self._entity_type, name=self._entity_name)
         self._info_panel.set_entity(entity)
+        self._graph_panel.set_entity(entity)
         if self._definition_panel is not None:
             self._definition_panel.set_entity(entity)
 
@@ -70,7 +76,9 @@ class RosEntityInspection(Screen):
 
             with Vertical(id="main"):
                 if self._definition_panel is None:
-                    with ScrollableContainer():
+                    with ScrollableContainer(id="main-upper", classes="main-half"):
+                        yield self._graph_panel
+                    with ScrollableContainer(classes="main-half"):
                         yield self._info_panel
                 else:
                     with ScrollableContainer(id="main-upper", classes="main-half"):

--- a/rtui2/screens.py
+++ b/rtui2/screens.py
@@ -6,7 +6,12 @@ from textual.screen import Screen
 from textual.widgets import Footer
 
 from .ros import RosClient, RosEntity, RosEntityType
-from .widgets import RosEntityInfoPanel, RosEntityListPanel, RosEntityGraphPanel, RosTypeDefinitionPanel
+from .widgets import (
+    RosEntityGraphPanel,
+    RosEntityInfoPanel,
+    RosEntityListPanel,
+    RosTypeDefinitionPanel,
+)
 
 
 class RosEntityInspection(Screen):

--- a/rtui2/widgets/__init__.py
+++ b/rtui2/widgets/__init__.py
@@ -1,6 +1,6 @@
+from .graph_panel import RosEntityGraphPanel
 from .info_panel import RosEntityInfoPanel
 from .list_panel import RosEntityListPanel
-from .graph_panel import RosEntityGraphPanel
 from .type_definition import RosTypeDefinitionPanel
 
 __all__ = [

--- a/rtui2/widgets/__init__.py
+++ b/rtui2/widgets/__init__.py
@@ -1,9 +1,11 @@
 from .info_panel import RosEntityInfoPanel
 from .list_panel import RosEntityListPanel
+from .graph_panel import RosEntityGraphPanel
 from .type_definition import RosTypeDefinitionPanel
 
 __all__ = [
     "RosEntityInfoPanel",
     "RosEntityListPanel",
+    "RosEntityGraphPanel",
     "RosTypeDefinitionPanel",
 ]

--- a/rtui2/widgets/graph_panel.py
+++ b/rtui2/widgets/graph_panel.py
@@ -4,7 +4,7 @@ from textual.widgets import Static, Tree
 from textual.widgets.tree import TreeNode
 from textual.app import ComposeResult
 
-from ..ros import RosClient, RosEntity
+from ..ros import RosClient, RosEntity, RosEntityType
 from ..ros.dependency_graph import RosDependencyGraph, RosDependencyNode
 
 
@@ -54,4 +54,8 @@ class RosEntityGraphPanel(Static):
                 child_node = parent.add(label)
                 self._populate_tree(child_node, child)
             else:
-                parent.add_leaf(label)
+                if child.entity.type == RosEntityType.Topic:
+                    topic_node = parent.add(label)
+                    topic_node.add_leaf("[yellow][No publisher][/yellow]")
+                else:
+                    parent.add_leaf(f"[green]{label}[/green]")

--- a/rtui2/widgets/graph_panel.py
+++ b/rtui2/widgets/graph_panel.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from textual.widgets import Static, Tree
-from textual.widgets.tree import TreeNode
+from rich.text import Text
 from textual.app import ComposeResult
 from textual.events import Key
-from rich.text import Text
+from textual.widgets import Static, Tree
+from textual.widgets.tree import TreeNode
 
 from ..ros import RosClient, RosEntity, RosEntityType
 from ..ros.dependency_graph import RosDependencyGraph, RosDependencyNode
@@ -28,8 +28,11 @@ class TreeLabel:
         text.stylize("bold underline")
         return text
 
+    @staticmethod
+    def error(msg: str) -> Text:
+        return Text(f"ERROR: {msg}", style="red")
+
     NO_PUBLISHER = Text("[No publisher]", style="yellow")
-    ERROR = lambda msg: Text(f"ERROR: {msg}", style="red")
 
     @staticmethod
     def is_no_publisher(label: str | Text) -> bool:
@@ -40,7 +43,9 @@ class TreeLabel:
 class RosEntityGraphPanel(Static):
     """ROSエンティティの依存関係をツリー表示するパネル"""
 
-    def __init__(self, ros: RosClient, entity: RosEntity | None = None, **kwargs) -> None:
+    def __init__(
+        self, ros: RosClient, entity: RosEntity | None = None, **kwargs
+    ) -> None:
         super().__init__(**kwargs)
         self._ros = ros
         self._entity = entity
@@ -124,7 +129,8 @@ class RosEntityGraphPanel(Static):
             return 0
 
         valid_children = [
-            child for child in node.children
+            child
+            for child in node.children
             if not TreeLabel.is_no_publisher(child.label)
         ]
 

--- a/rtui2/widgets/graph_panel.py
+++ b/rtui2/widgets/graph_panel.py
@@ -41,8 +41,6 @@ class TreeLabel:
 
 
 class RosEntityGraphPanel(Static):
-    """ROSエンティティの依存関係をツリー表示するパネル"""
-
     def __init__(
         self, ros: RosClient, entity: RosEntity | None = None, **kwargs
     ) -> None:
@@ -106,21 +104,21 @@ class RosEntityGraphPanel(Static):
 
     def on_tree_node_selected(self, event: Tree.NodeSelected) -> None:
         node = event.node
-        entity = node.data  # type: RosEntity | None
+        if self._should_update_subtree(node):
+            self._update_subtree(node)
 
+    def _should_update_subtree(self, node: TreeNode) -> bool:
+        entity = node.data
         if not isinstance(entity, RosEntity):
-            return
-
+            return False
         if not node.is_expanded:
-            return
-
+            return False
         if node.children and all(child.is_expanded for child in node.children):
-            return
-
+            return False
         if self._subtree_depth(node) > EXPAND_UP_TO_NODES:
-            return
+            return False
 
-        self._update_subtree(node)
+        return True
 
     def _update_subtree(self, node: TreeNode) -> None:
         entity = node.data

--- a/rtui2/widgets/graph_panel.py
+++ b/rtui2/widgets/graph_panel.py
@@ -3,11 +3,25 @@ from __future__ import annotations
 from textual.widgets import Static, Tree
 from textual.widgets.tree import TreeNode
 from textual.app import ComposeResult
+from rich.text import Text
 
 from ..ros import RosClient, RosEntity, RosEntityType
 from ..ros.dependency_graph import RosDependencyGraph, RosDependencyNode
 
 EXPANSION_DEPTH = 2
+
+
+class TreeLabel:
+    LEAF_NODE = lambda label: Text(label, style="green")
+    NO_PUBLISHER = Text("[No publisher]", style="yellow")
+    ERROR = lambda msg: Text(f"Error: {msg}", style="red")
+
+    @staticmethod
+    def is_placeholder_label(label: str | Text) -> bool:
+        """[No publisher]のようなplaceholding leafを判定"""
+        plain = label.plain if isinstance(label, Text) else str(label)
+        return plain.strip() == "No publisher"
+
 
 class RosEntityGraphPanel(Static):
     """ROSエンティティの依存関係をツリー表示するパネル"""
@@ -69,10 +83,9 @@ class RosEntityGraphPanel(Static):
             else:
                 if child.entity.type == RosEntityType.Topic:
                     topic_node = parent.add(label)
-                    topic_node.add_leaf("[yellow][No publisher][/yellow]")
-
+                    topic_node.add_leaf(TreeLabel.NO_PUBLISHER)
                     if depth < EXPANSION_DEPTH - 1:
                         topic_node.expand()
-
                 else:
-                    parent.add_leaf(f"[green]{label}[/green]")
+                    parent.add_leaf(TreeLabel.LEAF_NODE(label))
+

--- a/rtui2/widgets/graph_panel.py
+++ b/rtui2/widgets/graph_panel.py
@@ -6,6 +6,8 @@ from textual.events import Key
 from textual.widgets import Static, Tree
 from textual.widgets.tree import TreeNode
 
+from typing import Callable
+
 from ..ros import RosClient, RosEntity, RosEntityType
 from ..ros.dependency_graph import RosDependencyGraph, RosDependencyNode
 
@@ -42,11 +44,16 @@ class TreeLabel:
 
 class RosEntityGraphPanel(Static):
     def __init__(
-        self, ros: RosClient, entity: RosEntity | None = None, **kwargs
+        self,
+        ros: RosClient,
+        entity: RosEntity | None = None,
+        on_highlighted_changed: Callable[[RosEntity], None] | None = None,
+        **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self._ros = ros
         self._entity = entity
+        self._on_highlighted_changed = on_highlighted_changed
         self._tree: Tree[RosEntity] | None = None
 
     def compose(self) -> ComposeResult:
@@ -171,3 +178,9 @@ class RosEntityGraphPanel(Static):
             self.on_tree_node_selected(Tree.NodeSelected(selected_node))
 
             event.stop()
+
+    def on_tree_node_highlighted(self, event: Tree.NodeHighlighted) -> None:
+        node = event.node
+        entity = node.data
+        if isinstance(entity, RosEntity) and self._on_highlighted_changed:
+            self._on_highlighted_changed(entity)

--- a/rtui2/widgets/graph_panel.py
+++ b/rtui2/widgets/graph_panel.py
@@ -103,6 +103,9 @@ class RosEntityGraphPanel(Static):
         if entity.type != RosEntityType.Node:
             return
 
+        if node.children and all(child.is_expanded for child in node.children):
+            return
+
         if self._subtree_depth(node) > EXPANSION_DEPTH:
             return
 

--- a/rtui2/widgets/graph_panel.py
+++ b/rtui2/widgets/graph_panel.py
@@ -67,7 +67,7 @@ class RosEntityGraphPanel(Static):
         if self._entity is None:
             return
 
-        self._tree = Tree(self._entity.name, data=self._entity)
+        self._tree = Tree(TreeLabel.label(self._entity), data=self._entity)
         self.mount(self._tree)
 
         graph = RosDependencyGraph(self._entity, self._ros, max_depth=EXPANSION_DEPTH)

--- a/rtui2/widgets/graph_panel.py
+++ b/rtui2/widgets/graph_panel.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+from typing import Callable
+
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.events import Key
 from textual.widgets import Static, Tree
 from textual.widgets.tree import TreeNode
-
-from typing import Callable
 
 from ..ros import RosClient, RosEntity, RosEntityType
 from ..ros.dependency_graph import RosDependencyGraph, RosDependencyNode

--- a/rtui2/widgets/graph_panel.py
+++ b/rtui2/widgets/graph_panel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from textual.widgets import Static, Tree
 from textual.widgets.tree import TreeNode
 from textual.app import ComposeResult
+from textual.events import Key
 from rich.text import Text
 
 from ..ros import RosClient, RosEntity, RosEntityType
@@ -128,3 +129,22 @@ class RosEntityGraphPanel(Static):
             return 0
 
         return 1 + max(self._subtree_depth(child) for child in valid_children)
+
+    async def on_key(self, event: Key) -> None:
+        if event.key == "space":
+            selected_node = self._tree.cursor_node
+            if selected_node is None or selected_node.parent is None:
+                return
+
+            siblings = selected_node.parent.children
+            should_expand = not selected_node.is_expanded
+
+            for sibling in siblings:
+                if should_expand:
+                    sibling.expand()
+                else:
+                    sibling.collapse()
+
+            self.on_tree_node_selected(Tree.NodeSelected(selected_node))
+
+            event.stop()

--- a/rtui2/widgets/graph_panel.py
+++ b/rtui2/widgets/graph_panel.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from textual.widgets import Static, Tree
+from textual.widgets.tree import TreeNode
+from textual.app import ComposeResult
+
+from ..ros import RosClient, RosEntity
+from ..ros.dependency_graph import RosDependencyGraph, RosDependencyNode
+
+
+class RosEntityGraphPanel(Static):
+    """ROSエンティティの依存関係をツリー表示するパネル"""
+
+    def __init__(
+        self,
+        ros: RosClient,
+        entity: RosEntity | None = None,
+        *,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes, disabled=disabled)
+        self._ros = ros
+        self._entity = entity
+        self._tree = Tree("Dependency Graph")
+
+    def compose(self) -> ComposeResult:
+        yield self._tree
+
+    def on_mount(self) -> None:
+        if self._entity:
+            self.update_graph()
+
+    def set_entity(self, entity: RosEntity) -> None:
+        if entity != self._entity:
+            self._entity = entity
+            self.update_graph()
+
+    def update_graph(self) -> None:
+        self._tree.clear()
+        if self._entity is None:
+            return
+
+        graph = RosDependencyGraph(self._entity, self._ros)
+        self._populate_tree(self._tree.root, graph.root)
+        self._tree.root.expand()
+
+    def _populate_tree(self, parent: TreeNode, dep_node: RosDependencyNode) -> None:
+        for child in dep_node.children:
+            label = f"{child.entity.name}"
+            if child.children:
+                child_node = parent.add(label)
+                self._populate_tree(child_node, child)
+            else:
+                parent.add_leaf(label)


### PR DESCRIPTION
## Overview
This introduces a new feature to visualize ROS2 entity dependencies as an interactive tree structure. It adds a dependency graph model, a dedicated UI panel, and integrates this into the entity inspection workflow.
![output](https://github.com/user-attachments/assets/576b9ecd-81cd-4b26-948c-65cea6ce49af)

## Highlights
### Dependency Graph Model
Implemented RosDependencyGraph and RosDependencyNode classes to recursively model hierarchical relationships between ROS entities.

Supports:
- Node → Subscribed Topics
- Topic → Publishing Nodes

Skips system topics (e.g., /parameter_events) to maintain clarity.

### Graph UI Panel
Added a new widget: RosEntityGraphPanel that renders the dependency tree.

Features:
- Lazy subtree expansion
- Error handling (invalid/missing entity info)
- Styling for nodes/topics (color & underline)
- "Space" key to collapse/expand all items at the same level

## Notes
Tree nodes are color-coded:
- 🟩 Green for Nodes
- ⚪ White for Topics
- 🔶 Yellow for “No Publisher”
- 🔴 Red for errors