### PR TITLE
Add environment variable for ROS discovery server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,14 @@ TUI tool for ROS 2 Topic/Node debugging
 
 - Python
   - 3.10+
-- ROS2
+- ROS 2
   - Humble
   - Jazzy
+- DDS Implementation
+  - FastDDS Discovery Server mode supported
+    - Compatible with centralized discovery architectures
+    - Requires `ROS_DISCOVERY_SERVER` environment variable for discovery server endpoint
+    - Automatically sets [`ROS_SUPER_CLIENT=true`](https://fast-dds.docs.eprosima.com/en/v2.14.5/fastdds/env_vars/env_vars.html?highlight=super_client#ros-super-client) for enhanced discovery capabilities
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Commands:
     - `b/f`: Trace history backward and forward
     - `r`: Once more get list of nodes, topics or etc.
     - `q`: Terminate app
+- Set `ROS_DISCOVERY_SERVER` environment variable to enable discovery server mode
+  - e.g. `export ROS_DISCOVERY_SERVER=127.0.0.1:11811`
 
 ## License
 

--- a/rtui2/cli.py
+++ b/rtui2/cli.py
@@ -100,6 +100,8 @@ def main() -> None:
     cli.add_command(services)
 
     if is_ros2():
+        # for discovery server
+        environ["ROS_SUPER_CLIENT"] = "true"
         cli.add_command(action)
         type.add_command(type_action)
 

--- a/rtui2/cli.py
+++ b/rtui2/cli.py
@@ -101,7 +101,8 @@ def main() -> None:
 
     if is_ros2():
         # for discovery server
-        environ["ROS_SUPER_CLIENT"] = "true"
+        if "ROS_SUPER_CLIENT" not in environ:
+            environ["ROS_SUPER_CLIENT"] = "true"
         cli.add_command(action)
         type.add_command(type_action)
 


### PR DESCRIPTION
Set the `ROS_SUPER_CLIENT` environment variable to "true" for enabling the discovery server functionality in the CLI.

https://fast-dds.docs.eprosima.com/en/v2.14.5/fastdds/env_vars/env_vars.html?highlight=ros_super_client#ros-super-client